### PR TITLE
Solved bug at penalty detection

### DIFF
--- a/src/sslworld.cpp
+++ b/src/sslworld.cpp
@@ -808,7 +808,7 @@ void SSLWorld::posProcess()
                 continue;
             dReal rx, ry;
             robots[num]->getXY(rx, ry);
-            if (rx < -0.6 && abs(ry < 0.35))
+            if (rx < -0.6 && abs(ry) < 0.35)
             {
                 if (one_in_pen_area){
                     penalty = true;
@@ -856,7 +856,7 @@ void SSLWorld::posProcess()
                 continue;
             dReal rx, ry;
             robots[num]->getXY(rx, ry);
-            if (rx > 0.6 && abs(ry < 0.35))
+            if (rx > 0.6 && abs(ry) < 0.35)
             {
                 if (one_in_pen_area){
                     penalty = true;


### PR DESCRIPTION
The referee was scoring a penalty when the player was at x> 0.6 or x <-0.6 (depending on his team's side of the field), when in fact he should be checking to see if the player was contained in the goal rectangle.